### PR TITLE
Add serializer submatcher for relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Add `.serializer` submatcher for relationship matchers (`belong_to`, `have_one` and `have_many`)
+
 ## [1.0.0] - 2021-04-10
 
 - Initial release

--- a/lib/rspec_jsonapi_serializer/matchers.rb
+++ b/lib/rspec_jsonapi_serializer/matchers.rb
@@ -13,6 +13,8 @@ module RSpecJSONAPISerializer
   module Matchers
     # This allows us to assert attributes on a serializer, e.g.:
     # expect(serializer).to belong_to(:team)
+    # If you have a custom serializer, you can assert its value with the `serializer` submatcher
+    # expect(serializer).to belong_to(:team).serializer(TeamSerializer)
     def belong_to(expected)
       BelongToMatcher.new(expected)
     end
@@ -45,6 +47,8 @@ module RSpecJSONAPISerializer
 
     # This allows us to assert attributes on a serializer, e.g.:
     # expect(serializer).to have_many(:teams)
+    # If you have a custom serializer, you can assert its value with the `serializer` submatcher
+    # expect(serializer).to have_many(:teams).serializer(TeamSerializer)
     def have_many(expected)
       HaveManyMatcher.new(expected)
     end
@@ -61,6 +65,8 @@ module RSpecJSONAPISerializer
 
     # This allows us to assert attributes on a serializer, e.g.:
     # expect(serializer).to have_one(:team)
+    # If you have a custom serializer, you can assert its value with the `serializer` submatcher
+    # expect(serializer).to have_one(:team).serializer(TeamSerializer)
     def have_one(expected)
       HaveOneMatcher.new(expected)
     end

--- a/lib/rspec_jsonapi_serializer/matchers/association_matchers/serializer_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/association_matchers/serializer_matcher.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rspec_jsonapi_serializer/metadata/relationships"
+
+module RSpecJSONAPISerializer
+  module Matchers
+    module AssociationMatchers
+      class SerializerMatcher < Base
+        def initialize(value, relationship_target)
+          super(value)
+
+          @relationship_target  = relationship_target
+        end
+
+        def matches?(serializer_instance)
+          @serializer_instance = serializer_instance
+
+          actual == expected
+        end
+
+        def main_failure_message
+          [expected_message, actual_message].compact.join(", ")
+        end
+
+        private
+
+        attr_reader :relationship_target
+
+        def expected_message
+          "expected #{serializer_name} to use #{expected} as serializer for #{relationship_target}"
+        end
+
+        def actual_message
+          actual ? "got #{actual} instead" : nil
+        end
+
+        def actual
+          metadata.relationship(relationship_target).serializer
+        end
+
+        def metadata
+          Metadata::Relationships.new(serializer_instance)
+        end
+      end
+    end
+  end
+end

--- a/lib/rspec_jsonapi_serializer/matchers/belong_to_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/belong_to_matcher.rb
@@ -13,6 +13,10 @@ module RSpecJSONAPISerializer
         association_matcher.matches?(serializer_instance)
       end
 
+      def serializer(value)
+        association_matcher.serializer(value)
+      end
+
       def main_failure_message
         association_matcher.main_failure_message
       end

--- a/lib/rspec_jsonapi_serializer/matchers/have_many_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_many_matcher.rb
@@ -13,6 +13,10 @@ module RSpecJSONAPISerializer
         association_matcher.matches?(serializer_instance)
       end
 
+      def serializer(value)
+        association_matcher.serializer(value)
+      end
+
       def main_failure_message
         association_matcher.main_failure_message
       end

--- a/lib/rspec_jsonapi_serializer/matchers/have_one_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_one_matcher.rb
@@ -13,6 +13,10 @@ module RSpecJSONAPISerializer
         association_matcher.matches?(serializer_instance)
       end
 
+      def serializer(value)
+        association_matcher.serializer(value)
+      end
+
       def main_failure_message
         association_matcher.main_failure_message
       end

--- a/lib/rspec_jsonapi_serializer/metadata/relationships.rb
+++ b/lib/rspec_jsonapi_serializer/metadata/relationships.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+
+require "rspec_jsonapi_serializer/metadata/relationships"
+
+module RSpecJSONAPISerializer
+  module Metadata
+    class Relationships
+      def initialize(serializer)
+        @serializer = serializer
+      end
+
+      def relationship(key)
+        relationships.values.find { |relationship| relationship.key.to_s == key.to_s }
+      end
+
+      def relationships
+        serializer.class&.relationships_to_serialize || {}
+      end
+
+      private
+
+      attr_reader :serializer
+    end
+  end
+end


### PR DESCRIPTION
Currently, there is no way to do assertions on custom serializers for relationships.

This commit makes that happen.

If you have this type of relationship in a serializer:

```ruby
  has_one :owner, serializer: UserSerializer
```

It can now be tested with:

```ruby
expect(serializer).to have_one(:owner).serializer(UserSerializer)
```