### PR TITLE
Add id_method_name submatcher

### DIFF
--- a/lib/rspec_jsonapi_serializer/matchers.rb
+++ b/lib/rspec_jsonapi_serializer/matchers.rb
@@ -15,6 +15,8 @@ module RSpecJSONAPISerializer
     # expect(serializer).to belong_to(:team)
     # If you have a custom serializer, you can assert its value with the `serializer` submatcher
     # expect(serializer).to belong_to(:team).serializer(TeamSerializer)
+    # If you have a custom id, you can assert its value with the `id_method_name` submatcher
+    # expect(serializer).to belong_to(:team).id_method_name(:team_slug)
     def belong_to(expected)
       BelongToMatcher.new(expected)
     end
@@ -49,6 +51,8 @@ module RSpecJSONAPISerializer
     # expect(serializer).to have_many(:teams)
     # If you have a custom serializer, you can assert its value with the `serializer` submatcher
     # expect(serializer).to have_many(:teams).serializer(TeamSerializer)
+    # If you have a custom id, you can assert its value with the `id_method_name` submatcher
+    # expect(serializer).to have_many(:teams).id_method_name(:team_slugs)
     def have_many(expected)
       HaveManyMatcher.new(expected)
     end
@@ -67,6 +71,8 @@ module RSpecJSONAPISerializer
     # expect(serializer).to have_one(:team)
     # If you have a custom serializer, you can assert its value with the `serializer` submatcher
     # expect(serializer).to have_one(:team).serializer(TeamSerializer)
+    # If you have a custom id, you can assert its value with the `id_method_name` submatcher
+    # expect(serializer).to have_one(:team).id_method_name(:team_slug)
     def have_one(expected)
       HaveOneMatcher.new(expected)
     end

--- a/lib/rspec_jsonapi_serializer/matchers/association_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/association_matcher.rb
@@ -2,6 +2,7 @@
 
 require "rspec_jsonapi_serializer/matchers/base"
 require "rspec_jsonapi_serializer/matchers/association_matchers/serializer_matcher"
+require "rspec_jsonapi_serializer/matchers/association_matchers/id_method_name_matcher"
 require "rspec_jsonapi_serializer/metadata/relationships"
 
 module RSpecJSONAPISerializer
@@ -22,6 +23,12 @@ module RSpecJSONAPISerializer
 
       def serializer(value)
         add_submatcher AssociationMatchers::SerializerMatcher.new(value, expected)
+
+        self
+      end
+
+      def id_method_name(value)
+        add_submatcher AssociationMatchers::IdMethodNameMatcher.new(value, expected)
 
         self
       end

--- a/lib/rspec_jsonapi_serializer/matchers/association_matchers/id_method_name_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/association_matchers/id_method_name_matcher.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rspec_jsonapi_serializer/metadata/relationships"
+
+module RSpecJSONAPISerializer
+  module Matchers
+    module AssociationMatchers
+      class IdMethodNameMatcher < Base
+        def initialize(value, relationship_target)
+          super(value)
+
+          @relationship_target  = relationship_target
+        end
+
+        def matches?(serializer_instance)
+          @serializer_instance = serializer_instance
+
+          actual == expected
+        end
+
+        def main_failure_message
+          [expected_message, actual_message].compact.join(", ")
+        end
+
+        private
+
+        attr_reader :relationship_target
+
+        def expected_message
+          "expected #{serializer_name} to use #{expected} as id_method_name for #{relationship_target}"
+        end
+
+        def actual_message
+          actual ? "got #{actual} instead" : nil
+        end
+
+        def actual
+          metadata.relationship(relationship_target).id_method_name
+        end
+
+        def metadata
+          Metadata::Relationships.new(serializer_instance)
+        end
+      end
+    end
+  end
+end

--- a/lib/rspec_jsonapi_serializer/matchers/belong_to_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/belong_to_matcher.rb
@@ -13,6 +13,10 @@ module RSpecJSONAPISerializer
         association_matcher.matches?(serializer_instance)
       end
 
+      def id_method_name(value)
+        association_matcher.id_method_name(value)
+      end
+
       def serializer(value)
         association_matcher.serializer(value)
       end

--- a/lib/rspec_jsonapi_serializer/matchers/have_many_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_many_matcher.rb
@@ -13,6 +13,10 @@ module RSpecJSONAPISerializer
         association_matcher.matches?(serializer_instance)
       end
 
+      def id_method_name(value)
+        association_matcher.id_method_name(value)
+      end
+
       def serializer(value)
         association_matcher.serializer(value)
       end

--- a/lib/rspec_jsonapi_serializer/matchers/have_one_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_one_matcher.rb
@@ -13,6 +13,10 @@ module RSpecJSONAPISerializer
         association_matcher.matches?(serializer_instance)
       end
 
+      def id_method_name(value)
+        association_matcher.id_method_name(value)
+      end
+
       def serializer(value)
         association_matcher.serializer(value)
       end


### PR DESCRIPTION
This new matcher allows you to do assertion on relationships that use a custom foreign key.

```ruby
class User < ActiveRecord::Base
  belongs_to :team, foreign_key: :team_slug
end

class UserSerializer
  include JSONAPI::Serializer

  belongs_to :team, id_method_name: :team_slug
end
```

The new submatcher allows you to do this:

```ruby
expect(serializer).to belong_to(:team).id_method_name(:team_slug)
```
