### PR TITLE
Add object_method_name matcher

### DIFF
--- a/lib/rspec_jsonapi_serializer/matchers/association_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/association_matcher.rb
@@ -3,6 +3,7 @@
 require "rspec_jsonapi_serializer/matchers/base"
 require "rspec_jsonapi_serializer/matchers/association_matchers/serializer_matcher"
 require "rspec_jsonapi_serializer/matchers/association_matchers/id_method_name_matcher"
+require "rspec_jsonapi_serializer/matchers/association_matchers/object_method_name_matcher"
 require "rspec_jsonapi_serializer/metadata/relationships"
 
 module RSpecJSONAPISerializer
@@ -29,6 +30,12 @@ module RSpecJSONAPISerializer
 
       def id_method_name(value)
         add_submatcher AssociationMatchers::IdMethodNameMatcher.new(value, expected)
+
+        self
+      end
+
+      def object_method_name(value)
+        add_submatcher AssociationMatchers::ObjectMethodNameMatcher.new(value, expected)
 
         self
       end

--- a/lib/rspec_jsonapi_serializer/matchers/association_matchers/object_method_name_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/association_matchers/object_method_name_matcher.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rspec_jsonapi_serializer/metadata/relationships"
+
+module RSpecJSONAPISerializer
+  module Matchers
+    module AssociationMatchers
+      class ObjectMethodNameMatcher < Base
+        def initialize(value, relationship_target)
+          super(value)
+
+          @relationship_target  = relationship_target
+        end
+
+        def matches?(serializer_instance)
+          @serializer_instance = serializer_instance
+
+          actual == expected
+        end
+
+        def main_failure_message
+          [expected_message, actual_message].compact.join(", ")
+        end
+
+        private
+
+        attr_reader :relationship_target
+
+        def expected_message
+          "expected #{serializer_name} to use #{expected} as object_method_name for #{relationship_target}"
+        end
+
+        def actual_message
+          actual ? "got #{actual} instead" : nil
+        end
+
+        def actual
+          metadata.relationship(relationship_target).object_method_name
+        end
+
+        def metadata
+          Metadata::Relationships.new(serializer_instance)
+        end
+      end
+    end
+  end
+end

--- a/lib/rspec_jsonapi_serializer/matchers/belong_to_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/belong_to_matcher.rb
@@ -17,6 +17,10 @@ module RSpecJSONAPISerializer
         association_matcher.id_method_name(value)
       end
 
+      def object_method_name(value)
+        association_matcher.object_method_name(value)
+      end
+
       def serializer(value)
         association_matcher.serializer(value)
       end

--- a/lib/rspec_jsonapi_serializer/matchers/have_many_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_many_matcher.rb
@@ -17,6 +17,10 @@ module RSpecJSONAPISerializer
         association_matcher.id_method_name(value)
       end
 
+      def object_method_name(value)
+        association_matcher.object_method_name(value)
+      end
+
       def serializer(value)
         association_matcher.serializer(value)
       end

--- a/lib/rspec_jsonapi_serializer/matchers/have_one_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_one_matcher.rb
@@ -17,6 +17,10 @@ module RSpecJSONAPISerializer
         association_matcher.id_method_name(value)
       end
 
+      def object_method_name(value)
+        association_matcher.object_method_name(value)
+      end
+
       def serializer(value)
         association_matcher.serializer(value)
       end


### PR DESCRIPTION
This new matcher allows you to do assertion on relationships that use a custom method to get the associations for a record.

```ruby
class User < ActiveRecord::Base
  has_many :posts
end

class UserSerializer
  include JSONAPI::Serializer

  has_many :blog_posts, object_method_name: :posts
end
```

The new submatcher allows you to do this:

```ruby
expect(serializer).to have_many(:blog_posts).object_method_name(:posts)
```
